### PR TITLE
Merge updates before applying

### DIFF
--- a/src/y-redis.js
+++ b/src/y-redis.js
@@ -73,9 +73,8 @@ export class PersistenceDoc {
       logger('Fetched ', logging.BOLD, logging.PURPLE, (updates.length).toString().padEnd(2), logging.UNBOLD, logging.UNCOLOR, ' updates')
       this.mux(() => {
         this.doc.transact(() => {
-          updates.forEach(update => {
-            Y.applyUpdate(this.doc, update)
-          })
+          const mergedUpdates = Y.mergeUpdates(updates);
+          Y.applyUpdate(this.doc, mergedUpdates);
           const nextClock = startClock + updates.length
           if (this._clock < nextClock) {
             this._clock = nextClock


### PR DESCRIPTION
Fixes an issue where this hangs for a long time if there are a large number of upates.


Before (2.5 minutes):

![image](https://user-images.githubusercontent.com/3090066/138306221-0844d1c4-d062-4a05-9a3a-8f5f68367623.png)


After (1.4 seconds):

![image](https://user-images.githubusercontent.com/3090066/138306342-537c5078-547a-4fc5-80cb-793021642631.png)


See https://github.com/ueberdosis/hocuspocus/issues/230 for more context.
