### PR TITLE
Add replaceUpdatesWithEncodedState method

### DIFF
--- a/src/y-redis.js
+++ b/src/y-redis.js
@@ -99,6 +99,15 @@ export class PersistenceDoc {
       }
     })
   }
+
+  /**
+   * Replace existing redis list with a single update, reducing size of list and improving performance
+   */
+  replaceUpdatesWithEncodedState () {
+    return this.rp.redis.rpushBuffer(this.name + ':updates', Y.encodeStateAsUpdate(this.doc)).then(() => {
+      return this.rp.redis.ltrim(this.name + ':updates', -1, -1);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
The `replaceUpdatesWithEncodedState` will:
- save the current encoded state of the document as an update
- remove previous updates

This method will be useful if someone wants to keep their redis size small, as this will reduce the number of updates stored separately. 