### PR TITLE
feat: graceful shutdown

### DIFF
--- a/bin/auth-server-example.js
+++ b/bin/auth-server-example.js
@@ -76,7 +76,7 @@ app.get('/auth/perm/:room/:userid', async (res, req) => {
  * Resolves when the server started.
  */
 export const authServerStarted = promise.create((resolve, reject) => {
-  app.listen(port, (token) => {
+  const server = app.listen(port, (token) => {
     if (token) {
       logging.print(logging.GREEN, `[${appName}] Listening to port ${port}`)
       resolve()
@@ -86,4 +86,14 @@ export const authServerStarted = promise.create((resolve, reject) => {
       throw err
     }
   })
+
+  // Gracefully shut down the server when running in Docker
+  process.on("SIGTERM", shutDown)
+  process.on("SIGINT", shutDown)
+
+  function shutDown() {
+    console.log("Received SIGTERM/SIGINT - shutting down")
+    server.close()
+    process.exit(0)
+  }
 })

--- a/demos/auth-express/server.js
+++ b/demos/auth-express/server.js
@@ -73,6 +73,22 @@ app.get('/auth/perm/:room/:userid', async (req, res) => {
 // serve static files
 app.use(express.static('./'))
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Express Demo Auth server listening on port ${port}`)
 })
+
+// Gracefully shut down the server when running in Docker
+process.on("SIGTERM", shutDown)
+process.on("SIGINT", shutDown)
+
+function shutDown() {
+  console.log("Received kill signal, shutting down gracefully")
+  server.close(() => {
+    console.log("Closed out remaining connections")
+    process.exit(0)
+  })
+  setTimeout(() => {
+    console.error("Couldn'c sloe connections - forcefully shutting down")
+    process.exit(1)
+  }, 10000)
+}

--- a/demos/auth-express/server.js
+++ b/demos/auth-express/server.js
@@ -82,13 +82,13 @@ process.on("SIGTERM", shutDown)
 process.on("SIGINT", shutDown)
 
 function shutDown() {
-  console.log("Received kill signal, shutting down gracefully")
+  console.log("Received SIGTERM/SIGINT - shutting down gracefully")
   server.close(() => {
-    console.log("Closed out remaining connections")
+    console.log("Closed out remaining connections - shutting down")
     process.exit(0)
   })
   setTimeout(() => {
-    console.error("Couldn'c sloe connections - forcefully shutting down")
+    console.error("Couldn't close connections - forcefully shutting down")
     process.exit(1)
   }, 10000)
 }

--- a/demos/blocksuite/server.js
+++ b/demos/blocksuite/server.js
@@ -159,13 +159,13 @@ process.on("SIGTERM", shutDown)
 process.on("SIGINT", shutDown)
 
 function shutDown() {
-  console.log("Received kill signal, shutting down gracefully")
+  console.log("Received SIGTERM/SIGINT - shutting down gracefully")
   server.close(() => {
-    console.log("Closed out remaining connections")
+    console.log("Closed out remaining connections - shutting down")
     process.exit(0)
   })
   setTimeout(() => {
-    console.error("Couldn'c sloe connections - forcefully shutting down")
+    console.error("Couldn't close connections - forcefully shutting down")
     process.exit(1)
   }, 10000)
 }

--- a/demos/blocksuite/server.js
+++ b/demos/blocksuite/server.js
@@ -150,6 +150,22 @@ app.get('*', (req, res) => {
   res.sendFile(resolve(__dirname, 'index.html'))
 })
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Express Demo BlockSuite server listening on port ${port}`)
 })
+
+// Gracefully shut down the server when running in Docker
+process.on("SIGTERM", shutDown)
+process.on("SIGINT", shutDown)
+
+function shutDown() {
+  console.log("Received kill signal, shutting down gracefully")
+  server.close(() => {
+    console.log("Closed out remaining connections")
+    process.exit(0)
+  })
+  setTimeout(() => {
+    console.error("Couldn'c sloe connections - forcefully shutting down")
+    process.exit(1)
+  }, 10000)
+}


### PR DESCRIPTION
When running as PID=1 under Docker, SIGTERM/SIGINT need to be manually caught and handled, so when Docker is shutting down the servers don't shut down immediately but hang around until Docker gets tired (after 10 seconds) and forcefully kills them.