### PR TITLE
Move reading of auth-public-key down from top level

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -8,9 +8,6 @@ import * as json from 'lib0/json'
 import { registerYWebsocketServer } from '../src/ws.js'
 import * as promise from 'lib0/promise'
 
-const wsServerPublicKey = await ecdsa.importKeyJwk(json.parse(env.ensureConf('auth-public-key')))
-// const wsServerPrivateKey = await ecdsa.importKeyJwk(json.parse(env.ensureConf('auth-private-key')))
-
 class YWebsocketServer {
   /**
    * @param {uws.TemplatedApp} app
@@ -52,6 +49,7 @@ export const createYWebsocketServer = async ({
       throw new Error('Missing Token')
     }
     // verify that the user has a valid token
+    const wsServerPublicKey = await ecdsa.importKeyJwk(json.parse(env.ensureConf('auth-public-key')))
     const { payload: userToken } = await jwt.verifyJwt(wsServerPublicKey, token)
     if (userToken.yuserid == null) {
       throw new Error('Missing userid in user token!')


### PR DESCRIPTION
We are currently trying to integrate y-redis in our app. Because the code in src/server.js is very specific, we have rewritten that part ourselves and imported registerYWebsocketServer directly from src/ws.js. We then encountered the problem that the app didn't start because AUTH_PUBLIC_KEY was not set though we didn't use it. It was because it is read on top level in src/server.js and this file is executed always because it is exported in index.js. I don't see a reason why it must be read on top-level. Moving it into the function should fix the problem.