### PR TITLE
fix: memory leak in worker component

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -233,6 +233,7 @@ export class Api {
     let docChanged = false
     ydoc.once('afterTransaction', tr => {
       docChanged = tr.changed.size > 0
+      ydoc.destroy()
     })
     ydoc.transact(() => {
       docMessages?.messages.forEach(m => {


### PR DESCRIPTION
Fix memory leak in the worker component: ydoc instances were not properly released after applying updates and writing to storage.