### PR TITLE
Add y-protocols as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lib0": "^0.2.93",
         "redis": "^4.6.12",
         "uws": "github:uNetworking/uWebSockets.js#v20.40.0",
+        "y-protocols": "^1.0.5",
         "yjs": "^13.5.6"
       },
       "bin": {
@@ -6119,7 +6120,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
       "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
-      "dev": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lib0": "^0.2.93",
     "redis": "^4.6.12",
     "uws": "github:uNetworking/uWebSockets.js#v20.40.0",
+    "y-protocols": "^1.0.5",
     "yjs": "^13.5.6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Fixes #38

Added `y-protocols@^1.0.5` to package.json and package-lock.json since that is the version `y-websocket@^2.0.4` depends on as seen [here](https://github.com/yjs/y-websocket/blob/2c3c71e95cf7335e0b9261332168c0dcb9ea2e2a/package.json)  