### PR TITLE
Pin Node base image to version 20 to fix uWS incompatibility with latest LTS release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@
 # docker run -p 3002:3002 --env-file ./.env y-redis npm run start:server
 
 # Use an official Node.js runtime as a parent image
-# FROM node:20-alpine
-FROM node:lts-alpine3.19
+FROM node:20-alpine
 
 # Install glibc compatibility for alpine
 # See more at https://wiki.alpinelinux.org/wiki/Running_glibc_programs


### PR DESCRIPTION
## Description
This PR fixes build failures in the `server` and `worker` containers caused by the use of Node v22, which is incompatible with the uws library used in this project.

The `Dockerfile` previously used:
```
FROM node:lts-alpine3.19
```

The `lts` tag currently resolves to Node.js v22 which causes the following runtime error:
```
worker-1  | /usr/src/app/node_modules/uws/uws.js:22
worker-1  |             throw new Error('This version of uWS.js supports only Node.js LTS versions 16, 18 and 20 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).\n\n' + e.toString());
worker-1  |                   ^
worker-1  | 
worker-1  | Error: This version of uWS.js supports only Node.js LTS versions 16, 18 and 20 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).
worker-1  | 
worker-1  | Error: Cannot find module './uws_linux_x64_127.node'
worker-1  | Require stack:
worker-1  | - /usr/src/app/node_modules/uws/uws.js
worker-1  |     at /usr/src/app/node_modules/uws/uws.js:22:9
worker-1  |     at Object.<anonymous> (/usr/src/app/node_modules/uws/uws.js:24:3)
worker-1  |     at Module._compile (node:internal/modules/cjs/loader:1565:14)
worker-1  |     at Object..js (node:internal/modules/cjs/loader:1708:10)
worker-1  |     at Module.load (node:internal/modules/cjs/loader:1318:32)
worker-1  |     at Function._load (node:internal/modules/cjs/loader:1128:12)
worker-1  |     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
worker-1  |     at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
worker-1  |     at cjsLoader (node:internal/modules/esm/translators:263:5)
worker-1  |     at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:196:7)
worker-1  | 
worker-1  | Node.js v22.12.0
server-1  | /usr/src/app/node_modules/uws/uws.js:22
server-1  |             throw new Error('This version of uWS.js supports only Node.js LTS versions 16, 18 and 20 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).\n\n' + e.toString());
server-1  |                   ^
server-1  | 
server-1  | Error: This version of uWS.js supports only Node.js LTS versions 16, 18 and 20 on (glibc) Linux, macOS and Windows, on Tier 1 platforms (https://github.com/nodejs/node/blob/master/BUILDING.md#platform-list).
server-1  | 
server-1  | Error: Cannot find module './uws_linux_x64_127.node'
server-1  | Require stack:
server-1  | - /usr/src/app/node_modules/uws/uws.js
server-1  |     at /usr/src/app/node_modules/uws/uws.js:22:9
server-1  |     at Object.<anonymous> (/usr/src/app/node_modules/uws/uws.js:24:3)
server-1  |     at Module._compile (node:internal/modules/cjs/loader:1565:14)
server-1  |     at Object..js (node:internal/modules/cjs/loader:1708:10)
server-1  |     at Module.load (node:internal/modules/cjs/loader:1318:32)
server-1  |     at Function._load (node:internal/modules/cjs/loader:1128:12)
server-1  |     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
server-1  |     at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
server-1  |     at cjsLoader (node:internal/modules/esm/translators:263:5)
server-1  |     at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:196:7)
server-1  | 
server-1  | Node.js v22.12.0
worker-1 exited with code 1                                                        
server-1 exited with code 1          
```
Both `server-1` and `worker-1` containers crash at build.

## Changes
Replaced the moving LTS tag with a pinned Node.js version(v20):
```
- FROM node:lts-alpine3.19
+ FROM node:20-alpine
```

## Tests
Verified that:
- The `server` and `worker` containers now start successfully.
- No runtime errors occur during initialization.
