### PR TITLE
fix(init-db): preserve SSL query params when connecting to admin database

### DIFF
--- a/bin/init-db.js
+++ b/bin/init-db.js
@@ -16,7 +16,10 @@ async function init (postgresUrl) {
     // Step 1: Create database if URL includes one
     console.log(`[init-db] Ensuring database '${database}' exists...`)
     // Connect to default 'postgres' database for admin operations
-    const adminDbUrl = postgresUrl.replace(/\/[^/]*$/, '/postgres')
+    // Preserve query parameters (like ssl=require) when switching database
+    const url = new URL(postgresUrl)
+    url.pathname = '/postgres'
+    const adminDbUrl = url.toString()
     const adminSql = postgres(adminDbUrl, { max: 1 })
     try {
       const dbExists = await adminSql`


### PR DESCRIPTION
## Summary

When using PostgreSQL with SSL enabled (e.g., AWS RDS with `?ssl=require`), the `init-db.js` script loses query parameters when constructing the admin database URL for initial setup operations.

## Problem

The current regex-based approach:
```javascript
const adminDbUrl = postgresUrl.replace(/\/[^/]*$/, '/postgres')
```

While this works in simple cases, it's fragile and doesn't semantically handle URL components properly.

## Solution

Use the standard `URL` API to properly parse and reconstruct the URL:
```javascript
const url = new URL(postgresUrl)
url.pathname = '/postgres'
const adminDbUrl = url.toString()
```

## Benefits

- **Correctness:** Properly handles all URL components (protocol, auth, host, port, path, query)
- **SSL Support:** Preserves `?ssl=require` and other query parameters needed for secure connections
- **Maintainability:** Uses standard URL parsing instead of fragile regex
- **Edge Cases:** Handles special characters in passwords, unusual ports, etc.

## Testing

Tested against AWS RDS PostgreSQL with SSL required:
```bash
export POSTGRES=postgresql://user:pass@mydb.rds.amazonaws.com:5432/yhub?ssl=require
node bin/init-db.js
# Successfully creates database with SSL connection
```

## Breaking Changes

None - URLs without query params work identically to before.