### PR TITLE
Fix wrong content attribute names in unsafePersistDoc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,8 +142,8 @@ export class YHub {
      */
     const deleteAttrs = [Y.createContentAttribute('deleteAt', ms)]
     if (by != null) {
-      insertAttrs.push(Y.createContentAttribute('insertBy', by))
-      deleteAttrs.push(Y.createContentAttribute('deleteBy', by))
+      insertAttrs.push(Y.createContentAttribute('insert', by))
+      deleteAttrs.push(Y.createContentAttribute('delete', by))
     }
     const contentmap = Y.createContentMapFromContentIds(contentids, insertAttrs, deleteAttrs)
     await this.persistence.store(room, { lastClock, gcDoc: ydoc, nongcDoc: ydoc, contentids: Y.encodeContentIds(contentids), contentmap: Y.encodeContentMap(contentmap) })


### PR DESCRIPTION
## Summary

- Fix `unsafePersistDoc` using `insertBy`/`deleteBy` instead of `insert`/`delete` for user attribution content attributes
- Aligns attribute names with `createContentMapFromParams` and the Activity endpoint

Fixes #42