### PR TITLE
Fix unawaited Redis calls in stream.js

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -340,7 +340,7 @@ export class Stream {
         multi.xAck(this.workerStreamName, this.workerGroupName, id)
         multi.xDel(this.workerStreamName, id)
       }
-      multi.exec()
+      await multi.exec()
     }
     const tasks = reclaimedTasks.messages.map(m => {
       if (m?.message.compact != null) {
@@ -389,7 +389,7 @@ export class Stream {
     const startTime = time.getUnixTime()
     const result = await computeResult()
     const computeTime = math.floor((time.getUnixTime() - startTime) / 1000)
-    this.redis.set(key, Buffer.from(result), { EX: this.cacheTtl + computeTime * 2 })
+    this.redis.set(key, Buffer.from(result), { EX: this.cacheTtl + computeTime * 2 }).catch(err => log('cache write error: ', { err }))
     return result
   }
 }


### PR DESCRIPTION
## Summary

Fixes two unawaited Redis calls in `src/stream.js` that can contribute to Redis protocol errors and process crashes:

- **`claimTasks` (line 343)**: `multi.exec()` was not awaited when cleaning up ghost tasks. This fire-and-forget `MULTI/EXEC` can cause unhandled rejections and potentially corrupt Redis connection state if errors occur during the transaction.
- **`cachedGet` (line 392)**: `this.redis.set(...)` was called without awaiting or catching errors. If the cached value (a serialized Yjs doc) is very large or the connection has issues, this produces unhandled promise rejections that can crash the process. Added `.catch()` to log errors gracefully.

These issues were identified while investigating a `ERR Protocol error: invalid bulk length` crash in production.

## Changes

- `multi.exec()` → `await multi.exec()` in `claimTasks`
- Added `.catch(err => log('cache write error: ', { err }))` to the fire-and-forget `redis.set()` in `cachedGet`

## Test plan

- [ ] Verify lint passes (`npm run lint`)
- [ ] Run existing test suite (`npm test`)
- [ ] Monitor Redis protocol errors in production after deploy