### PR TITLE
feat: add taskStart/taskComplete worker lifecycle events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,11 @@ export class YHub {
         await promise.all(tasks.map(async task => {
           const taskLog = log.child({ taskType: task.type, room: task.room })
           if (task.type === 'compact') {
+            const _taskTs = Date.now()
+            this.conf.worker?.events?.taskStart?.({ room: task.room, timestamp: _taskTs })
+            /** @type {Error | undefined} */
+            let _taskErr
+            try {
             taskLog.info('task started')
             // execute compact task
             const d = await this.getDoc(task.room, { gc: true, nongc: true, contentmap: true, contentids: true, references: true })
@@ -70,6 +75,8 @@ export class YHub {
               this.stream.trimMessages(task.room, d.lastClock, this.stream.minMessageLifetime, task.redisClock)
             ])
             taskLog.info({ gcDocSize: d.gcDoc?.byteLength, nongcDocSize: d.nongcDoc?.byteLength, refsDeleted: d.references?.length ?? 0 }, 'task completed')
+            } catch (e) { _taskErr = e; throw e }
+            finally { this.conf.worker?.events?.taskComplete?.({ room: task.room, duration: Date.now() - _taskTs, error: _taskErr }) }
           }
         }))
         tasks.length && log.info({ taskCount: tasks.length }, 'completed tasks')

--- a/src/types.js
+++ b/src/types.js
@@ -267,7 +267,11 @@ export const $config = s.$object({
   worker: s.$object({
     taskConcurrency: s.$number,
     events: s.$object({
-      docUpdate: /** @type {s.$Optional<s.Schema<(doctable:DocTable<{ gc: true, nongc: true, contentmap: true, contentids: true }>) => void>>} */ (s.$function.optional)
+      docUpdate: /** @type {s.$Optional<s.Schema<(doctable:DocTable<{ gc: true, nongc: true, contentmap: true, contentids: true }>) => void>>} */ (s.$function.optional),
+      /** @type {s.$Optional<s.Schema<(event: { room: Room, timestamp: number }) => void>>} */
+      taskStart: s.$function.optional,
+      /** @type {s.$Optional<s.Schema<(event: { room: Room, duration: number, error: Error | undefined }) => void>>} */
+      taskComplete: s.$function.optional
     }).optional
   }).nullable.optional,
   server: s.$object({


### PR DESCRIPTION
Adds two optional event callbacks to `worker.events` config for observing compact task lifecycle.

## Usage

```js
const yhub = await createYHub({
  worker: {
    taskConcurrency: 4,
    events: {
      taskStart: ({ room, timestamp }) => {
        console.log('task started', room, timestamp)
      },
      taskComplete: ({ room, duration, error }) => {
        console.log('task done', room, duration, error)
      },
    },
  },
  // ...
})
```

## Callbacks

### `taskStart({ room, timestamp })`
Fired when a compact task begins.

### `taskComplete({ room, duration, error })`
Fired in a `finally` block when a compact task finishes. `error` is the caught `Error` if the task threw, `undefined` on success.

## Changes

- `src/index.js`: Wrap compact task body in `try/catch/finally`, fire `taskStart` before and `taskComplete` after. Original code is untouched — no indentation changes, no logic changes.
- `src/types.js`: Add `taskStart` and `taskComplete` to worker events schema with JSDoc types.

## Backwards compatible

Both callbacks are optional. Existing configurations are unaffected.