### PR TITLE
Fix CI test workflow (MinIO, env, pino-pretty)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,21 +36,17 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-      minio:
-        image: minio/minio
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd "curl -sf http://localhost:9000/minio/health/live"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
         run: node --env-file .env --env-file .env.testing ./bin/init-db.js
 
       - name: Run tests
-        run: node --expose-gc --max-old-space-size=8192 --env-file .env --env-file .env.testing tests/index.js | pino-pretty -S -L debug
+        run: node --expose-gc --max-old-space-size=8192 --env-file .env --env-file .env.testing tests/index.js | npx pino-pretty -S -L debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,10 @@ jobs:
         ports:
           - 9000:9000
         options: >-
-          --health-cmd "mc ready local"
+          --health-cmd "curl -sf http://localhost:9000/minio/health/live"
           --health-interval 5s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
         run: node --env-file .env --env-file .env.testing ./bin/init-db.js
 
       - name: Run tests
-        run: node --expose-gc --max-old-space-size=8192 --env-file .env --env-file .env.testing tests/index.js | npx pino-pretty -S -L debug
+        run: node --expose-gc --max-old-space-size=8192 --env-file .env --env-file .env.testing tests/index.js | npx pino-pretty@13.1.3 -S -L debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
           POSTGRES_TESTING=postgres://yhub:yhub@localhost:5432/yhub-testing
           LOG=*
           EOF
+          touch .env.testing
 
       - name: Initialize databases
         run: node --env-file .env --env-file .env.testing ./bin/init-db.js


### PR DESCRIPTION
## Summary

Fixes the CI test workflow which was broken by three independent issues:

- **MinIO container fails to start**: Newer `minio/minio` images no longer default to `server /data`, so the container just prints help and exits. GitHub Actions service containers don't support custom commands, so MinIO is now started as a workflow step with the explicit `server /data` command and a `curl`-based health check.
- **Missing `.env.testing`**: `node --env-file .env.testing` fails when the file doesn't exist. Added `touch .env.testing` to create an empty one in CI.
- **`pino-pretty` not on PATH**: The binary is installed as a devDependency in `node_modules/.bin` but not on the CI shell's PATH. Switched to `npx pino-pretty`.

## Test plan

- [x] CI test workflow passes