### PR TITLE
Add Redis client options and await taskStart

### DIFF
--- a/API.md
+++ b/API.md
@@ -179,6 +179,7 @@ const yhub = await createYHub(config)
 | `redis.taskDebounce` | `number` | no | Milliseconds before a worker picks up a compaction task. Default: 120 000 |
 | `redis.minMessageLifetime` | `number` | no | Minimum time in ms that update messages are kept in Redis streams before compaction. Default: 60 000 |
 | `redis.cacheTtl` | `number` | no | TTL in seconds for cached API responses. Default: 10 |
+| `redis.clientOptions` | `object` | no | Additional options passed to the node-redis client, e.g. `{ pingInterval: 10000 }`. YHub still controls `url` and its Lua `scripts`; `redis.socket` is merged into the final socket config. |
 | `redis.socket` | `object` | no | Custom socket options merged into the Redis client socket config. See [node-redis socket options](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md#socket-options) for available options. |
 | `postgres` | `string` | yes | PostgreSQL connection string |
 | `persistence` | `PersistencePlugin[]` | yes | One or more storage plugins (e.g. `S3PersistenceV1`). At least one is required. |
@@ -189,6 +190,8 @@ const yhub = await createYHub(config)
 | `worker` | `object \| null` | no | Background compaction worker config. Set to `null` to disable. |
 | `worker.taskConcurrency` | `number` | yes* | Maximum number of compaction tasks to process in parallel |
 | `worker.events.docUpdate` | `function` | no | Called after each compaction with the merged `DocTable` |
+| `worker.events.taskStart` | `function` | no | Called before a compaction task starts. May return a promise; YHub waits for it before compacting. |
+| `worker.events.taskComplete` | `function` | no | Called after a compaction task completes or fails. |
 
 **Example: full server setup**
 
@@ -200,6 +203,8 @@ const yhub = await createYHub({
   redis: {
     url: 'redis://localhost:6379',
     prefix: 'yhub:prod',
+    // Optional: pass node-redis client options, such as keepalive PINGs.
+    // clientOptions: { pingInterval: 10000 },
     // Optional: custom socket options for TLS, etc.
     // socket: { rejectUnauthorized: false, ca: fs.readFileSync('/path/to/ca.pem', 'utf-8') }
   },

--- a/API.md
+++ b/API.md
@@ -179,7 +179,7 @@ const yhub = await createYHub(config)
 | `redis.taskDebounce` | `number` | no | Milliseconds before a worker picks up a compaction task. Default: 120 000 |
 | `redis.minMessageLifetime` | `number` | no | Minimum time in ms that update messages are kept in Redis streams before compaction. Default: 60 000 |
 | `redis.cacheTtl` | `number` | no | TTL in seconds for cached API responses. Default: 10 |
-| `redis.clientOptions` | `object` | no | Additional options passed to the node-redis client, e.g. `{ pingInterval: 10000 }`. YHub still controls `url` and its Lua `scripts`; `redis.socket` is merged into the final socket config. |
+| `redis.clientOptions` | `object` | no | Additional options passed to the node-redis client, e.g. `{ pingInterval: 10000 }`. YHub still controls `url`; `redis.socket` is merged into the final socket config; `clientOptions.scripts` are merged with YHub's Lua scripts. |
 | `redis.socket` | `object` | no | Custom socket options merged into the Redis client socket config. See [node-redis socket options](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md#socket-options) for available options. |
 | `postgres` | `string` | yes | PostgreSQL connection string |
 | `persistence` | `PersistencePlugin[]` | yes | One or more storage plugins (e.g. `S3PersistenceV1`). At least one is required. |

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export class YHub {
           const taskLog = log.child({ taskType: task.type, room: task.room })
           if (task.type === 'compact') {
             const taskTs = time.getUnixTime()
-            this.conf.worker?.events?.taskStart?.({ room: task.room, timestamp: taskTs })
+            await this.conf.worker?.events?.taskStart?.({ room: task.room, timestamp: taskTs })
             /**
              * @type {Error | null}
              */

--- a/src/stream.js
+++ b/src/stream.js
@@ -111,9 +111,12 @@ export class Stream {
      * @type {Map<string, { lastReceivedClock: string, subs: Set<StreamSubscriber> }>}
      */
     this.subUpdates = new Map()
-    this.redisClientConf = {
+    const redisClientOptions = /** @type {import('@redis/client').RedisClientOptions} */ ({ ...(config.redis.clientOptions ?? {}) })
+    delete redisClientOptions.scripts
+    this.redisClientConf = /** @type {import('@redis/client').RedisClientOptions} */ ({
+      ...redisClientOptions,
       url: config.redis.url,
-      socket: {
+      socket: /** @type {import('@redis/client').RedisClientOptions['socket']} */ ({
         connectTimeout: 20000,
         /**
          * @param {number} retries
@@ -127,9 +130,10 @@ export class Stream {
           log.warn({ retries, delayMs: delay }, 'redis reconnecting')
           return delay
         },
+        ...redisClientOptions?.socket,
         ...config.redis.socket
-      }
-    }
+      })
+    })
     this.redis = redis.createClient({
       ...this.redisClientConf,
       // scripting: https://github.com/redis/node-redis/#lua-scripts
@@ -200,7 +204,7 @@ export class Stream {
     /**
      * Second instance to fetch things concurrent to the other connection.
      *
-     * @type {typeof this.redis | null}
+     * @type {ReturnType<typeof redis.createClient> | null}
      */
     this.redisSubscriptions = null
     this._subRunning = false
@@ -217,10 +221,12 @@ export class Stream {
   async _runSub () {
     if (!this._subRunning) {
       this._subRunning = true
-      if (this.redisSubscriptions === null) {
-        this.redisSubscriptions = redis.createClient(this.redisClientConf)
-        this.redisSubscriptions.on('error', /** @param {Error} err */ err => log.error({ err }, 'Redis subscription client error'))
-        await this.redisSubscriptions.connect()
+      let redisSubscriptions = this.redisSubscriptions
+      if (redisSubscriptions === null) {
+        redisSubscriptions = redis.createClient(this.redisClientConf)
+        redisSubscriptions.on('error', /** @param {Error} err */ err => log.error({ err }, 'Redis subscription client error'))
+        await redisSubscriptions.connect()
+        this.redisSubscriptions = redisSubscriptions
       }
       while (this.subs.size > 0 || this.subUpdates.size > 0) {
         // update subs
@@ -233,7 +239,7 @@ export class Stream {
         })
         this.subUpdates.clear()
         try {
-          const ms = await this.getMessages(array.from(this.subs.entries()).map(([room, s]) => ({ room, clock: s.lastReceivedClock })), { redisClient: this.redisSubscriptions, blocking: true })
+          const ms = await this.getMessages(array.from(this.subs.entries()).map(([room, s]) => ({ room, clock: s.lastReceivedClock })), { redisClient: redisSubscriptions, blocking: true })
           let nsubCounter = 0
           for (let i = 0; i < ms.length; i++) {
             const m = ms[i]
@@ -267,7 +273,7 @@ export class Stream {
   /**
    * @param {Array<{room: t.Room|string, clock: string}>} rooms room-clock pairs
    * @param {object} opts
-   * @param {typeof this.redis} [opts.redisClient]
+   * @param {any} [opts.redisClient]
    * @param {boolean} [opts.blocking]
    * @return {Promise<Array<{ room: t.Room, messages: Array<t.Message & { redisClock: string }>, lastClock: string, streamName: string }>>}
    */

--- a/src/stream.js
+++ b/src/stream.js
@@ -141,6 +141,7 @@ export class Stream {
       ...this.redisClientConf,
       // scripting: https://github.com/redis/node-redis/#lua-scripts
       scripts: {
+        ...this.redisClientConf.scripts,
         addMessage: redis.defineScript({
           NUMBER_OF_KEYS: 1,
           SCRIPT: `

--- a/src/stream.js
+++ b/src/stream.js
@@ -23,6 +23,10 @@ const log = logger.child({ module: 'stream' })
  */
 
 /**
+ * @typedef {Pick<ReturnType<typeof redis.createClient>, 'withTypeMapping'>} RedisReadClient
+ */
+
+/**
  * @param {t.Room} room
  * @param {string} prefix
  */
@@ -111,8 +115,7 @@ export class Stream {
      * @type {Map<string, { lastReceivedClock: string, subs: Set<StreamSubscriber> }>}
      */
     this.subUpdates = new Map()
-    const redisClientOptions = /** @type {import('@redis/client').RedisClientOptions} */ ({ ...(config.redis.clientOptions ?? {}) })
-    delete redisClientOptions.scripts
+    const redisClientOptions = config.redis.clientOptions ?? {}
     this.redisClientConf = /** @type {import('@redis/client').RedisClientOptions} */ ({
       ...redisClientOptions,
       url: config.redis.url,
@@ -273,18 +276,19 @@ export class Stream {
   /**
    * @param {Array<{room: t.Room|string, clock: string}>} rooms room-clock pairs
    * @param {object} opts
-   * @param {any} [opts.redisClient]
+   * @param {RedisReadClient} [opts.redisClient]
    * @param {boolean} [opts.blocking]
    * @return {Promise<Array<{ room: t.Room, messages: Array<t.Message & { redisClock: string }>, lastClock: string, streamName: string }>>}
    */
-  async getMessages (rooms, { redisClient = this.redis, blocking = false } = {}) {
+  async getMessages (rooms, { redisClient, blocking = false } = {}) {
     if (rooms.length === 0) {
       await promise.wait(50)
       return []
     }
     const streams = rooms.map(asset => ({ key: s.$string.check(asset.room) ? asset.room : encodeRoomName(asset.room, this.prefix), id: asset.clock || '0' }))
     log.debug({ streamCount: streams.length }, 'retrieving messages')
-    const reads = /** @type {Array<{name: Buffer, messages: Array<{id: Buffer, message: Record<string, Buffer>}>}> | null} */ (await redisClient.withTypeMapping({
+    const readClient = redisClient ?? this.redis
+    const reads = /** @type {Array<{name: Buffer, messages: Array<{id: Buffer, message: Record<string, Buffer>}>}> | null} */ (await readClient.withTypeMapping({
       [redis.RESP_TYPES.BLOB_STRING]: Buffer
     }).xRead(
       streams,

--- a/src/types.js
+++ b/src/types.js
@@ -254,10 +254,10 @@ export const $config = s.$object({
     cacheTtl: s.$number.optional,
     /**
      * Additional options passed to the Redis client.
-     * Merged before YHub's required url, socket defaults, and scripts.
-     * @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url' | 'scripts'>>>}
+     * Merged before YHub's required url and socket defaults. Custom scripts are merged with YHub scripts.
+     * @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url'>>>}
      */
-    clientOptions: /** @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url' | 'scripts'>>>} */ (s.$any.optional),
+    clientOptions: /** @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url'>>>} */ (s.$any.optional),
     /**
      * Custom socket options passed to the Redis client (e.g. `{ tls: true, rejectUnauthorized: false, ca: '...' }`).
      * Merged into the default socket config (which sets connectTimeout and reconnectStrategy).

--- a/src/types.js
+++ b/src/types.js
@@ -253,6 +253,12 @@ export const $config = s.$object({
      */
     cacheTtl: s.$number.optional,
     /**
+     * Additional options passed to the Redis client.
+     * Merged before YHub's required url, socket defaults, and scripts.
+     * @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url' | 'scripts'>>>}
+     */
+    clientOptions: /** @type {s.$Optional<s.Schema<Omit<import('@redis/client').RedisClientOptions, 'url' | 'scripts'>>>} */ (s.$any.optional),
+    /**
      * Custom socket options passed to the Redis client (e.g. `{ tls: true, rejectUnauthorized: false, ca: '...' }`).
      * Merged into the default socket config (which sets connectTimeout and reconnectStrategy).
      * @type {s.$Optional<s.Schema<import('@redis/client').RedisClientOptions['socket']>>}
@@ -268,7 +274,7 @@ export const $config = s.$object({
     taskConcurrency: s.$number,
     events: s.$object({
       docUpdate: /** @type {s.$Optional<s.Schema<(doctable:DocTable<{ gc: true, nongc: true, contentmap: true, contentids: true }>) => void>>} */ (s.$function.optional),
-      taskStart: /** @type {s.$Optional<s.Schema<(event: { room: Room, timestamp: number }) => void>>} */ (s.$function.optional),
+      taskStart: /** @type {s.$Optional<s.Schema<(event: { room: Room, timestamp: number }) => void | Promise<void>>>} */ (s.$function.optional),
       taskComplete: /** @type {s.$Optional<s.Schema<(event: { room: Room, duration: number, error: Error|null }) => void>>} */ (s.$function.optional)
     }).optional
   }).nullable.optional,


### PR DESCRIPTION
## Summary

- Await `worker.events.taskStart` before a compaction task starts, allowing async setup to complete before YHub reads and persists the document.
- Add `redis.clientOptions` so deployments can pass node-redis client options such as `pingInterval` without adding one-off YHub config fields.
- Apply the Redis client options to both the primary client and the subscription/read client.
- Merge `redis.clientOptions.scripts` with YHub's internal Lua scripts, with YHub's script names taking precedence on collisions.
- Document the new Redis option and the worker task lifecycle hooks.
