### PR TITLE
feat(ws): catch + log throws inside the open callback so per-room failures self-describe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@y/redis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@y/redis",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "AGPL-3.0 OR PROPRIETARY",
       "dependencies": {
         "lib0": "^0.2.93",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@y/redis",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@y/redis",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "AGPL-3.0 OR PROPRIETARY",
       "dependencies": {
         "lib0": "^0.2.93",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@y/redis",
-  "version": "0.1.6",
+  "name": "@papermillio/y-redis",
+  "version": "0.1.7",
   "description": "Scalable websocket provider for Yjs using redis",
   "sideEffects": false,
   "type": "module",
@@ -53,7 +53,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yjs/y-redis.git"
+    "url": "https://github.com/papermillio/y-redis.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "keywords": [
     "Yjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papermillio/y-redis",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Scalable websocket provider for Yjs using redis",
   "sideEffects": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papermillio/y-redis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Scalable websocket provider for Yjs using redis",
   "sideEffects": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papermillio/y-redis",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Scalable websocket provider for Yjs using redis",
   "sideEffects": false,
   "type": "module",

--- a/src/api.js
+++ b/src/api.js
@@ -233,6 +233,7 @@ export class Api {
     let docChanged = false
     ydoc.once('afterTransaction', tr => {
       docChanged = tr.changed.size > 0
+      ydoc.destroy()
     })
     ydoc.transact(() => {
       docMessages?.messages.forEach(m => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
 export * from './ws.js'
 export * from './api.js'
 export * from './server.js'
-console.debug('Using Papermill Y-WebSocket Server')

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export * from './ws.js'
 export * from './api.js'
 export * from './server.js'
+console.debug('Using Papermill Y-WebSocket Server')

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -83,6 +83,8 @@ export const mergeMessages = messages => {
       )
     )
   }))
+
+  aw.destroy()
   return result
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -69,10 +69,10 @@ export const createYWebsocketServer = async ({
   await promise.create((resolve, reject) => {
     app.listen(port, (token) => {
       if (token) {
-        logging.print(logging.GREEN, '[y-redis] Listening to port ', port)
+        logging.print(logging.GREEN, '[y-redis(papermill)] Listening to port ', port)
         resolve()
       } else {
-        const err = error.create('[y-redis] Failed to lisen to port ' + port)
+        const err = error.create('[y-redis(papermill)] Failed to listen to port ' + port)
         reject(err)
         throw err
       }

--- a/src/ws.js
+++ b/src/ws.js
@@ -146,25 +146,45 @@ export const registerYWebsocketServer = async (app, pattern, store, checkAuth, {
       const user = ws.getUserData()
       log(() => ['client connected (uid=', user.id, ', ip=', Buffer.from(ws.getRemoteAddressAsText()).toString(), ')'])
       const stream = api.computeRedisRoomStreamName(user.room, 'index', redisPrefix)
-      user.subs.add(stream)
-      ws.subscribe(stream)
-      user.initialRedisSubId = subscriber.subscribe(stream, redisMessageSubscriber).redisId
-      const indexDoc = await client.getDoc(user.room, 'index')
-      if (indexDoc.ydoc.store.clients.size === 0) {
-        initDocCallback(user.room, 'index', client)
-      }
-      if (user.isClosed) return
-      ws.cork(() => {
-        ws.send(protocol.encodeSyncStep1(Y.encodeStateVector(indexDoc.ydoc)), true, false)
-        ws.send(protocol.encodeSyncStep2(Y.encodeStateAsUpdate(indexDoc.ydoc)), true, true)
-        if (indexDoc.awareness.states.size > 0) {
-          ws.send(protocol.encodeAwarenessUpdate(indexDoc.awareness, array.from(indexDoc.awareness.states.keys())), true, true)
+      // uWS does not await the async open callback, so a throw inside the
+      // body lands as an unhandled rejection on Node's microtask queue —
+      // invisible without a global listener, and on some configurations
+      // silently dropped. Wrap the whole body so the room context reaches
+      // the logs synchronously; otherwise a per-room failure (e.g. a Yjs
+      // decode throw inside getDoc/applyUpdateV2, or a downstream encode)
+      // shows up at the load balancer as a 502 with no server-side trace.
+      try {
+        user.subs.add(stream)
+        ws.subscribe(stream)
+        user.initialRedisSubId = subscriber.subscribe(stream, redisMessageSubscriber).redisId
+        const indexDoc = await client.getDoc(user.room, 'index')
+        if (indexDoc.ydoc.store.clients.size === 0) {
+          initDocCallback(user.room, 'index', client)
         }
-      })
-      if (api.isSmallerRedisId(indexDoc.redisLastId, user.initialRedisSubId)) {
-        // our subscription is newer than the content that we received from the api
-        // need to renew subscription id and make sure that we catch the latest content.
-        subscriber.ensureSubId(stream, indexDoc.redisLastId)
+        if (user.isClosed) return
+        ws.cork(() => {
+          ws.send(protocol.encodeSyncStep1(Y.encodeStateVector(indexDoc.ydoc)), true, false)
+          ws.send(protocol.encodeSyncStep2(Y.encodeStateAsUpdate(indexDoc.ydoc)), true, true)
+          if (indexDoc.awareness.states.size > 0) {
+            ws.send(protocol.encodeAwarenessUpdate(indexDoc.awareness, array.from(indexDoc.awareness.states.keys())), true, true)
+          }
+        })
+        if (api.isSmallerRedisId(indexDoc.redisLastId, user.initialRedisSubId)) {
+          // our subscription is newer than the content that we received from the api
+          // need to renew subscription id and make sure that we catch the latest content.
+          subscriber.ensureSubId(stream, indexDoc.redisLastId)
+        }
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err)
+        console.error(`[y-redis ws.open] FAILED room="${user.room}" uid=${user.id} err=${msg}`)
+        if (err && err.stack) console.error(err.stack)
+        // Close the WS so the client and the load balancer see a clean
+        // termination instead of a stalled half-open connection. Best-effort
+        // — if `ws` is already torn down `end` throws and we have nothing
+        // useful to do with that second error.
+        try {
+          ws.end(1011, 'open handler error')
+        } catch (_) {}
       }
     },
     message: (ws, messageBuffer) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
   },
   "exclude": [
     "**/dist",
-    "./demos/blocksuite/"
+    "./demos/**/"
   ]
 }


### PR DESCRIPTION
## Why

Some Playground sub-rooms (`financials`, `contents-footer`, plus apparently any never-before-seen room id) 502 deterministically against curl against staging, but produce no server-side log line and no Sentry event. Investigation traces in `papermillio/flow#2016`:

- The yauth callback succeeds with `access: rw` and the perm callback returns in <30 ms.
- The store wrapper added in flow#2016 logs `[store] retrieveDoc ok room="…+financials" ms=51 result=present refs=1 docLen=3722` — so `client.getDoc(...)` did return a populated doc.
- Cloud Run still returns 502 to the client ~110 ms in, with no further sync container output.
- Sentry is configured and `Sentry.init` runs in staging, yet the inbox is empty — i.e. the throw never reaches Sentry's default `onUnhandledRejection` handler.

The only path that explains "store call succeeded, no Sentry, 502 anyway" is a throw inside the `open` callback **after** `await client.getDoc(...)` — most likely `Y.encodeStateVector` or `Y.encodeStateAsUpdate` failing on a doc whose binary state survives `mergeUpdatesV2` but trips one of the subsequent encoders, or the `ws.send` calls failing on backpressure for certain bytes. uWS calls the async open callback synchronously and discards the returned promise, so a throw is at best an unhandled rejection; on the deployed Node config it appears to be silently dropped.

This patch wraps the open body in a try/catch that prints the room + stack synchronously, then `ws.end()`s with 1011 so the load balancer sees a clean termination instead of a stalled half-open connection. After this lands, the next failing room produces a self-describing log line in the sync request stream.

## Key details

- **Try/catch covers the whole body** — `ws.subscribe`, the synchronous `subscriber.subscribe`, the awaited `client.getDoc`, `initDocCallback`, and the `ws.cork`/encode/send block. Anything that throws inside any of those names the room in the same log line.
- **`ws.end(1011, 'open handler error')`** sends a Close frame with the "Internal Error" code so the WS state transitions cleanly. The call itself is best-effort; if `ws` is already torn down it throws, and a second error is silently swallowed because there's nothing useful to do with it.
- **Success path is byte-for-byte identical.** The diff is a try/catch envelope; no statements re-ordered, no early returns introduced, no log lines added on the happy path (the existing `log()` call still fires).
- **Version bumped to 0.1.8** so the consuming sync project can pin against the change.
- **No new dependencies, no test changes.** The test suite under `tests/` doesn't currently exercise an open-handler throw; adding fault-injection plumbing for one diagnostic catch would be a larger PR. The patch's verification will be operational: deploy to staging, re-probe the failing rooms, confirm the new log line names the throw.

## Test plan

```bash
node --check src/ws.js     # ws.js parses
git diff origin/master..HEAD src/ws.js   # try/catch envelope only
```

- [x] `node --check` passes on the patched file
- [x] Diff against `v0.1.7` is the try/catch envelope plus the version bump
- [ ] Publish 0.1.8 (`npm version 0.1.8 && npm publish` after this merges) and bump `@papermillio/y-redis` in the sync project's package.json
- [ ] Deploy `sync` to staging
- [ ] Re-run the curl probe against `…/svR0rn9l11JV5RXUhgR6+default+financials` — expect the next 502 to be accompanied by a `[y-redis ws.open] FAILED room="…+financials" uid=… err=…` line plus a stack
- [ ] If the stack points at `Y.encodeStateVector` / `Y.encodeStateAsUpdate`, the root cause is a Yjs doc whose Firestore-persisted bytes round-trip through `mergeUpdatesV2` but trip the encoder — fix is to re-save the doc or seed it cleanly

Context, the prior investigation (flow#2010), and the matching store-wrapper PR (flow#2016) are in `papermillio/flow` under `context/prompts/2026-06-06T01-sync-open-handler-instrumentation.md`.
