### PR TITLE
Verifiable asset deletion: listRoomAssets, deleteReferencesNow, plugin deleteNow

### DIFF
--- a/API.md
+++ b/API.md
@@ -648,6 +648,62 @@ createApiEndpoint('recheck-auth', {
 > a room stream that contains an `auth:check:v1` entry (for up to `minMessageLifetime`). Deploy the
 > new version to all processes before the first `recheckAuth` call.
 
+#### `persistence.listRoomAssets(room)`
+
+Every asset persisted for a room, decoded from the row columns. Does **not** call the persistence
+plugins, so it never fetches from object storage.
+
+```ts
+persistence.listRoomAssets(
+  room: { org: string, docid: string, branch: string }
+): Promise<Array<{ assetId: AssetId, asset: Asset }>>
+```
+
+Use this rather than `retrieveDoc(room, { references: true })` when the list has to be complete:
+`retrieveDoc` only reports a reference once the plugin *retrieve* for it succeeded, so an object
+that is temporarily unreadable hides its row — and with it the `assetId` needed to ever delete
+that object. For reads that is a sensible degradation; for deletion or inventory it silently
+under-reports.
+
+#### `persistence.deleteReferencesNow(references)`
+
+Like [`deleteReferences`](#), but deletes each asset from the persistence plugins **first**,
+awaiting every one, and removes the database rows only once all of them are confirmed gone.
+Rejects instead of leaving rows that point at surviving objects.
+
+```ts
+persistence.deleteReferencesNow(
+  references: Array<{ assetId: AssetId, asset: Asset }>
+): Promise<void>
+```
+
+`deleteReferences` is tuned for compaction: it schedules the plugin deletes without awaiting them
+(a slow object store can't stall compaction, and readers still holding the previous `t` keep
+working) and always removes the rows. That trade-off is right there, but it means a failed object
+delete leaves data behind with nothing pointing at it. Use `deleteReferencesNow` when the deletion
+has to be verifiable — deleting a document for good, or satisfying a data-retention requirement.
+
+Requires the configured plugins to implement `deleteNow`; rejects if no plugin claims an asset,
+rather than skipping it.
+
+```js
+// permanently delete one room, verifiably
+const assets = await yhub.persistence.listRoomAssets(room)
+await yhub.persistence.deleteReferencesNow(assets)
+// throws unless every object *and* row is gone
+```
+
+> Deleting persisted rows does not stop the document coming back: `store()` is an insert, so a
+> later compaction of stream residue re-creates it. Disconnect writers first — e.g.
+> [`recheckAuth(room, { forceDisconnect: true })`](#yhubrecheckauthroom-opts) — and disable
+> compaction for the room.
+
+#### `PersistencePlugin.deleteNow(assetId, assetInfo)`
+
+Optional counterpart to `delete`. Deletes immediately, awaits completion, and rejects on failure,
+so callers can rely on the object being gone. `delete` remains the deferred, fire-and-forget
+variant used by compaction. A plugin returns `false` when the asset isn't its own.
+
 #### `yhub.agentTask(room, opts, handler)`
 
 Run an LLM agent task against a room. The handler receives a freshly hydrated `Y.Doc` (snapshot of the room's current state) and a new `Awareness` instance bound to it. Edits made inside the handler are streamed to all connected clients in real time with attribution derived from the options. The returned promise resolves with the handler's return value **only after** the agent's awareness has been cleared.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### New Features
+
+- **Verifiable asset deletion.** Three additive pieces that make it possible to delete a document's persisted data and *prove* it is gone, without changing any existing behaviour. ([API docs](API.md#persistencelistroomassetsroom))
+  - `persistence.listRoomAssets(room)` — every asset persisted for a room, decoded from the row columns without calling the plugins. Unlike `retrieveDoc(room, { references: true })` it cannot omit a row whose object is temporarily unreadable, which is exactly the row a deletion must not miss.
+  - `persistence.deleteReferencesNow(references)` — deletes objects first, awaited, and removes rows only once every object is confirmed gone; rejects otherwise. `deleteReferences` keeps its current compaction-tuned semantics (deferred, fire-and-forget plugin deletes, rows always removed).
+  - `PersistencePlugin.deleteNow(assetId, assetInfo)` — optional immediate, awaited delete. Implemented for the S3 plugin; `delete` is unchanged.
+
+
 ## [0.3.1]
 
 ### New Features

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -234,6 +234,42 @@ export class Persistence {
   async deleteReferences (references) {
     log.debug({ referenceCount: references.length }, 'deleting references')
     references.forEach(ref => tryPersistencePluginDelete(this.plugins, ref.assetId, ref.asset))
+    await this._deleteReferenceRows(references)
+  }
+
+  /**
+   * Like `deleteReferences`, but deletes the assets from the persistence plugins *first*,
+   * awaiting each one, and only removes the database rows once every asset is confirmed gone.
+   * Rejects instead of leaving rows that point at surviving objects.
+   *
+   * `deleteReferences` is tuned for compaction: it schedules the plugin deletes without awaiting
+   * them (so a slow object store can't stall compaction, and readers still holding the previous
+   * `t` keep working) and always removes the rows. That is the right trade-off there, but it
+   * means a failed object delete silently leaves data behind with nothing left pointing at it.
+   * Use this variant when the deletion has to be verifiable — e.g. deleting a document for good.
+   *
+   * Requires the plugins to implement `deleteNow`; rejects if no plugin claims an asset.
+   *
+   * @param {Array<{ assetId: t.AssetId, asset: t.Asset }>} references
+   * @return {Promise<void>}
+   */
+  async deleteReferencesNow (references) {
+    log.debug({ referenceCount: references.length }, 'deleting references (immediate)')
+    await promise.all(references.map(async ref => {
+      if (ref.asset.type !== 'asset:retrievable:v1') return
+      for (const plugin of this.plugins) {
+        if (plugin.deleteNow != null && await plugin.deleteNow(ref.assetId, ref.asset)) return
+      }
+      throw new Error(`no plugin deleted asset ${t.assetIdToString(ref.assetId)}`)
+    }))
+    await this._deleteReferenceRows(references)
+  }
+
+  /**
+   * @param {Array<{ assetId: t.AssetId, asset: t.Asset }>} references
+   * @return {Promise<void>}
+   */
+  async _deleteReferenceRows (references) {
     /**
      * org, docid, branch, t[]
      * @type {Map<string,Map<string,Map<string,Set<string>>>>}
@@ -256,6 +292,46 @@ export class Persistence {
     await promise.all(deleteQuery.map(dq => this.sql`
       DELETE FROM yhub_ydoc_v1 WHERE org = ${dq.org} AND docid = ${dq.docid} AND branch = ${dq.branch} AND t = ANY(${dq.ts})
     `))
+  }
+
+  /**
+   * Every asset persisted for a room, decoded from the row columns without fetching anything
+   * from the persistence plugins.
+   *
+   * Unlike `retrieveDoc(room, { references: true })`, this can't omit a row: `retrieveDoc` only
+   * reports a reference once the plugin *retrieve* for it succeeded, so a temporarily unreadable
+   * object hides its row — and with it the `assetId` needed to ever delete that object. This is
+   * for deletion and inventory, where a silently short list is a correctness bug rather than a
+   * degraded read.
+   *
+   * @param {t.Room} room
+   * @return {Promise<Array<{ assetId: t.AssetId, asset: t.Asset }>>}
+   */
+  async listRoomAssets (room) {
+    const rows = await this.sql`
+      SELECT t, gcDoc, nongcDoc, contentmap, contentids
+        FROM yhub_ydoc_v1
+       WHERE org = ${room.org} AND docid = ${room.docid} AND branch = ${room.branch}
+    `
+    /**
+     * @type {Array<{ assetId: t.AssetId, asset: t.Asset }>}
+     */
+    const assets = []
+    rows.forEach(row => {
+      /**
+       * @param {t.AssetId} assetId
+       * @param {Buffer|null} column
+       */
+      const add = (assetId, column) => {
+        if (column == null) return
+        assets.push({ assetId, asset: /** @type {t.Asset} */ (buffer.decodeAny(column)) })
+      }
+      add(object.assign({ type: /** @type {const} */ ('id:ydoc:v1'), gc: true, t: row.t }, room), row.gcdoc)
+      add(object.assign({ type: /** @type {const} */ ('id:ydoc:v1'), gc: false, t: row.t }, room), row.nongcdoc)
+      add(object.assign({ type: /** @type {const} */ ('id:contentmap:v1'), t: row.t }, room), row.contentmap)
+      add(object.assign({ type: /** @type {const} */ ('id:contentids:v1'), t: row.t }, room), row.contentids)
+    })
+    return assets
   }
 
   async destroy () {

--- a/src/plugins/s3.js
+++ b/src/plugins/s3.js
@@ -139,4 +139,18 @@ export class S3PersistenceV1 {
     }, 10_000)
     return true
   }
+
+  /**
+   * Delete now, awaited, so the caller can rely on the object being gone.
+   *
+   * @param {t.AssetId} assetId
+   * @param {t.Asset} assetInfo
+   */
+  async deleteNow (assetId, assetInfo) {
+    if (assetInfo.type !== 'asset:retrievable:v1' || assetInfo.plugin !== this.pluginid) {
+      return false
+    }
+    await this.s3client.removeObject(this.bucket, t.assetIdToString(assetId))
+    return true
+  }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -225,6 +225,10 @@ export const $task = $compactTask
  * @property {null|((assetId: AssetId, asset: Asset)=>Promise<RetrievableAsset?>)} [PersistPlugin.store]
  * @property {null|((assetId: AssetId, assetInfo: Asset)=>Promise<Asset?>)} [PersistPlugin.retrieve]
  * @property {null|((assetId: AssetId, assetInfo: Asset)=>Promise<boolean>)} [PersistPlugin.delete]
+ * @property {null|((assetId: AssetId, assetInfo: Asset)=>Promise<boolean>)} [PersistPlugin.deleteNow]
+ *   Optional. Delete immediately, awaiting completion and rejecting on failure. `delete` stays
+ *   the deferred, fire-and-forget variant used by compaction; this one is used by
+ *   `Persistence.deleteReferencesNow` where the deletion has to be verifiable.
  */
 
 /**

--- a/tests/storage.tests.js
+++ b/tests/storage.tests.js
@@ -83,3 +83,77 @@ export const testStorage = async tc => {
     t.info('delete references')
   }
 }
+
+/**
+ * `listRoomAssets` must report every persisted asset, including ones whose object can't
+ * currently be read — those are exactly the ones a deletion must not miss.
+ *
+ * @param {t.TestCase} tc
+ */
+export const testListRoomAssets = async tc => {
+  const org = tc.testName
+  const room = { org, docid: 'index', branch: 'main' }
+
+  const ydoc1 = new Y.Doc()
+  ydoc1.get().setAttr('a', 1)
+  await storeDoc(org, 'index', ydoc1)
+  const ydoc2 = new Y.Doc()
+  ydoc2.get().setAttr('b', 2)
+  await storeDoc(org, 'index', ydoc2)
+
+  t.info('listing assets without touching the persistence plugins')
+  const assets = await yhub.persistence.listRoomAssets(room)
+  // two stores × four columns (gc ydoc, nongc ydoc, contentmap, contentids)
+  t.assert(assets.length === 2 * 4)
+  t.assert(assets.every(a => a.assetId.org === org && a.assetId.docid === 'index'))
+  t.assert(assets.some(a => a.assetId.type === 'id:ydoc:v1' && a.assetId.gc === true))
+  t.assert(assets.some(a => a.assetId.type === 'id:ydoc:v1' && a.assetId.gc === false))
+  t.assert(assets.some(a => a.assetId.type === 'id:contentmap:v1'))
+  t.assert(assets.some(a => a.assetId.type === 'id:contentids:v1'))
+
+  t.info('an unrelated room is unaffected')
+  t.assert((await yhub.persistence.listRoomAssets({ org, docid: 'other', branch: 'main' })).length === 0)
+}
+
+/**
+ * `deleteReferencesNow` must remove the rows only after every object is confirmed deleted, so a
+ * failing object store can never leave data behind with nothing pointing at it.
+ *
+ * @param {t.TestCase} tc
+ */
+export const testDeleteReferencesNow = async tc => {
+  const org = tc.testName
+  const room = { org, docid: 'index', branch: 'main' }
+  const ydoc = new Y.Doc()
+  ydoc.get().setAttr('a', 1)
+  await storeDoc(org, 'index', ydoc)
+
+  const assets = await yhub.persistence.listRoomAssets(room)
+  t.assert(assets.length > 0)
+  const retrievable = assets.filter(a => a.asset.type === 'asset:retrievable:v1')
+
+  if (retrievable.length === 0) {
+    t.info('no plugin offloaded these assets — rows are deleted directly')
+    await yhub.persistence.deleteReferencesNow(assets)
+    t.assert((await yhub.persistence.listRoomAssets(room)).length === 0)
+    return
+  }
+
+  t.info('a failing deleteNow must leave every row in place')
+  const plugins = yhub.persistence.plugins
+  const originals = plugins.map(p => p.deleteNow)
+  plugins.forEach(p => { p.deleteNow = async () => { throw new Error('object store unavailable') } })
+  let failed = false
+  try {
+    await yhub.persistence.deleteReferencesNow(assets)
+  } catch (e) {
+    failed = true
+  }
+  plugins.forEach((p, i) => { p.deleteNow = originals[i] })
+  t.assert(failed)
+  t.assert((await yhub.persistence.listRoomAssets(room)).length === assets.length)
+
+  t.info('and a successful one removes both objects and rows')
+  await yhub.persistence.deleteReferencesNow(assets)
+  t.assert((await yhub.persistence.listRoomAssets(room)).length === 0)
+}


### PR DESCRIPTION
Adds three additive pieces that make it possible to delete a document's persisted data and *prove* it is gone. No existing behaviour changes — 234 insertions, 0 deletions.

### Why

`deleteReferences` is tuned for its caller, compaction (`store(new row)` → `deleteReferences(old rows)`), and its current semantics are right there: scheduling the plugin deletes without awaiting them keeps a slow object store off the compaction critical path, the 10s delay protects readers still holding the previous `t`, and always removing the rows avoids leaking them on the hot path.

But that combination means a failed object delete removes the only rows naming the object. Since `store()` offloads unconditionally for `branch === 'main'`, effectively every byte lives in object storage and the row holds a stub — so deleting rows deletes pointers, not data. For a data-retention requirement, "deleted" has to mean the objects are provably gone.

There's a related gap in enumeration: `retrieveDoc(room, { references: true })` only reports a reference once the plugin *retrieve* for it succeeded (`retrieved && references?.push(...)`), so a temporarily unreadable object hides its row — and with it the `assetId` needed to ever delete that object. A transient storage error strands a row permanently. That's a sensible degradation for reads, but it silently under-reports for deletion or inventory.

### What's here

- **`persistence.listRoomAssets(room)`** — every asset for a room, decoded from the row columns, no plugin calls. Complete by construction, so deletion can be verified and retried.
- **`persistence.deleteReferencesNow(references)`** — objects first and awaited, rows only once all are confirmed gone; rejects otherwise. `deleteReferences` keeps its exact current behaviour.
- **`PersistencePlugin.deleteNow(assetId, assetInfo)`** — optional immediate, awaited delete. Implemented for the S3 plugin; `delete` untouched. Optional on the interface, so existing plugins keep working.

Composed:

```js
const assets = await yhub.persistence.listRoomAssets(room)
await yhub.persistence.deleteReferencesNow(assets)
```

### Notes

- `deleteReferencesNow` fails closed: it rejects if no plugin claims an offloaded asset, rather than skipping it. Plugins other than S3 need a `deleteNow` before they can be used with it — happy to add Azure/GCS if you'd like them in scope.
- Docs added to `API.md`, including a callout that deleting rows doesn't stop a document coming back (`store()` is an insert, so a later compaction of stream residue re-creates it) and that writers should be disconnected first — `recheckAuth(room, { forceDisconnect: true })` covers the client half nicely.
- Two tests added to `tests/storage.tests.js`, following the existing conventions there.

### Testing

`npm run lint` (standard + tsc) passes. I could not run the integration suite locally — it needs Valkey/Postgres/MinIO via `compose.yaml` and I don't have Docker on this machine — so the two new tests are **unverified against real infra**; please run them. I did exercise both new methods against stubbed `sql` and plugins to check the decode path, the ordering (objects before rows), that rows survive a rejecting `deleteNow`, and that an unclaimed asset rejects rather than being skipped.

Happy to adjust naming, split this up, or fold it into a higher-level `deleteDoc(room)` if you'd prefer that shape — see the linked issue for the fuller picture.
